### PR TITLE
Dockerfile now uses SourceMod v1.10 instead of v1.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 FROM bitnami/minideb:stretch
 
 LABEL maintainer=rays3t
-LABEL version="1.3.0"
+LABEL version="1.3.1"
 LABEL description="A docker container for building sourcemod plugins (.sp), based on a minimalist debian/stretch. \
 This is intended to be used in an CI environment like GitLab. \
 It also adds a little wrapper script for the spcomp that abstracts the sourcemod libs from your plugin ones"
@@ -37,7 +37,7 @@ USER smuser
 WORKDIR /home/smuser
 
 # Pull the latest stable sourcemod version
-RUN BASE_SM_DL_URL=http://www.sourcemod.net/smdrop/1.9 && \
+RUN BASE_SM_DL_URL=http://www.sourcemod.net/smdrop/1.10 && \
 	LATEST_SM_VERSION=`wget $BASE_SM_DL_URL/sourcemod-latest-linux -q -O -` && \
 	echo Detected sourcemod version: $LATEST_SM_VERSION && \
 	wget -qO sourcemod.tar.gz $BASE_SM_DL_URL/$LATEST_SM_VERSION


### PR DESCRIPTION
Well, I made this PR in GitLab and then saw that you have the same repository over here on GitHub. Here's the exact same edit, just to keep things in sync!